### PR TITLE
Adjustment for changes in the baro lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,5 @@ build-FlightControllerControlPanel_v1-Desktop_Qt_5_10_0_MinGW_32bit-Release/ui_m
 *.sln
 *.db-shm
 *.db-wal
+
+.vs/

--- a/FlightController_v2_0/FlightController_v2_0.ino
+++ b/FlightController_v2_0/FlightController_v2_0.ino
@@ -195,7 +195,9 @@ void setup()
 
 void loop()
 {
+	// This is the only two things inside the loop()
+	// Every other function/method/task have to use one of this objects
 	tasker.run();
-	baro.runBarometer(); // this method uses planned tasks which need to be checked as fast as possible
+	taskPlanner.runPlanner();
 }
 

--- a/FlightController_v2_0/Storage.cpp
+++ b/FlightController_v2_0/Storage.cpp
@@ -8,10 +8,11 @@ namespace Storage
 {
 	// Objects
 	FC_ObjectTasker tasker(MaxAmtOfTaskerTasks);
+	FC_TaskPlanner taskPlanner(MaxAmtOfTaskPlannerTasks);
 	FC_MainCommunication com(&Serial1, 45);
 	FC_MPU6050Lib mpu;
 	FC_HMC5883L_Lib compass;
-	// Barometer object is created inside the library
+	FC_MS5611_Lib baro(&taskPlanner);
 	FC_Motors motors;
 	DebugSystem debug(&Serial);
 

--- a/FlightController_v2_0/Storage.h
+++ b/FlightController_v2_0/Storage.h
@@ -15,6 +15,7 @@
 
 #include <FC_ObjectTasker.h>
 #include <FC_Task.h>
+#include <FC_TaskPlanner.h>
 #include <MyPID.h>
 #include <FC_Communication_Base.h>
 #include "FC_MainCommunication.h"
@@ -46,9 +47,11 @@ namespace Storage
 
     // Objects
     extern FC_ObjectTasker tasker;
+    extern FC_TaskPlanner taskPlanner;
     extern FC_MainCommunication com;
     extern FC_MPU6050Lib mpu;
     extern FC_HMC5883L_Lib compass;
+    extern FC_MS5611_Lib baro;
     extern FC_Motors motors;
     extern DebugSystem debug;
 

--- a/FlightController_v2_0/config.h
+++ b/FlightController_v2_0/config.h
@@ -19,7 +19,8 @@ namespace config
 	const float MainDeltaTimeInSeconds = 1.0f / (float)MainFrequeny; //  = 1/250  (250Hz)
 	const uint16_t MainInterval = (uint16_t)(MainDeltaTimeInSeconds * 1000000.0); // [micro seconds] interval of main tasks
 
-	const uint8_t MaxAmtOfTaskerTasks = 20; // tasks array size inside tasker
+	const uint8_t MaxAmtOfTaskerTasks = 25; // tasks array size inside tasker
+	const uint8_t MaxAmtOfTaskPlannerTasks = 7; // max amount of tasks planned at once
 
 
 	// mpu6050


### PR DESCRIPTION
Now baro instance have to be created outside the library. TaskPlanner object pointer also have to be created and passed to the baro contructor